### PR TITLE
Update for using qt6

### DIFF
--- a/Anime/metadata.desktop
+++ b/Anime/metadata.desktop
@@ -11,3 +11,4 @@ ConfigFile=theme.conf
 TranslationsDirectory=translations
 Theme-Id=Elegant
 Theme-API=2.0
+QtVersion=6


### PR DESCRIPTION
Fixes bug: The theme at "/usr/share/sddm/themes/anime" requires missing "/usr/bin/sddm-greeter" . Using fallback theme.